### PR TITLE
PowerManagerService: Optimize button illumination

### DIFF
--- a/services/core/java/com/android/server/power/PowerManagerService.java
+++ b/services/core/java/com/android/server/power/PowerManagerService.java
@@ -1593,12 +1593,17 @@ public final class PowerManagerService extends SystemService
                             + screenOffTimeout - screenDimDuration;
                     if (now < nextTimeout) {
                         int buttonBrightness;
-                        if (mButtonBrightnessOverrideFromWindowManager >= 0) {
-                            buttonBrightness = mButtonBrightnessOverrideFromWindowManager;
+                        /* we want the brightness only to be set while device is awake */
+                        if (mWakefulness == WAKEFULNESS_AWAKE) {
+                            if (mButtonBrightnessOverrideFromWindowManager >= 0) {
+                                buttonBrightness = mButtonBrightnessOverrideFromWindowManager;
+                            } else {
+                                buttonBrightness = mButtonBrightness;
+                            }
                         } else {
-                            buttonBrightness = mButtonBrightness;
+                            /* otherwise set it to 0 */
+                            buttonBrightness = 0;
                         }
-
                         if (mButtonTimeout != 0 && now > mLastUserActivityTime + mButtonTimeout) {
                              mButtonsLight.setBrightness(0);
                         } else {


### PR DESCRIPTION
The current implementation of button/keyboard illumination is a bit flaky
When the device goes into deepsleep before the illumination time has expired
the buttons stay illuminated all time

The issue is fixed with this commit by setting button and keyboard brightness
to 0 when wakefullness state is not WAKEFULNESS_AWAKE because there is no point
to still illuminate the buttons when device is already dozing or dreaming

Change-Id: I01e66462271df57a6840a9ab9f40a7b51228c736

Conflicts:
    services/core/java/com/android/server/power/PowerManagerService.java
