### PR TITLE
bootanimation: Only try to shutdown the mediaplayer if it was prepared

### DIFF
--- a/cmds/bootanimation/BootAnimation.cpp
+++ b/cmds/bootanimation/BootAnimation.cpp
@@ -797,20 +797,22 @@ bool BootAnimation::movie()
 
     }
 
-    ALOGD("waiting for media player to complete.");
-    struct timespec timeout;
-    clock_gettime(CLOCK_REALTIME, &timeout);
-    timeout.tv_sec += 5; //timeout after 5s.
+    if (isMPlayerPrepared) {
+        ALOGD("waiting for media player to complete.");
+        struct timespec timeout;
+        clock_gettime(CLOCK_REALTIME, &timeout);
+        timeout.tv_sec += 5; //timeout after 5s.
 
-    pthread_mutex_lock(&mp_lock);
-    while (!isMPlayerCompleted) {
-        int err = pthread_cond_timedwait(&mp_cond, &mp_lock, &timeout);
-        if (err == ETIMEDOUT) {
-            break;
+        pthread_mutex_lock(&mp_lock);
+        while (!isMPlayerCompleted) {
+            int err = pthread_cond_timedwait(&mp_cond, &mp_lock, &timeout);
+            if (err == ETIMEDOUT) {
+                break;
+            }
         }
+        pthread_mutex_unlock(&mp_lock);
+        ALOGD("media player is completed.");
     }
-    pthread_mutex_unlock(&mp_lock);
-    ALOGD("media player is completed.");
 
     pthread_cond_destroy(&mp_cond);
     pthread_mutex_destroy(&mp_lock);


### PR DESCRIPTION
The bootanimation tries to shutdown the mediaplayer gracefully by waiting
on an asynchronous shutdown event for 5 seconds.

If, however, there is no boot sound, that asynchronous shutdown event will
never happen and the animation will be stopped for 5 seconds before shutting
down.

Visibly, this fixes the issue where the bootanimation would simply stop near
the end for exactly 5 seconds.

Change-Id: I77f5631368c7d9b9fef7941a6278af9c36032044
