### PR TITLE
Camera : allow camera to use power key as shutter

### DIFF
--- a/core/java/android/view/Window.java
+++ b/core/java/android/view/Window.java
@@ -814,6 +814,10 @@ public abstract class Window {
     }
 
     private void setPrivateFlags(int flags, int mask) {
+        if ((flags & mask & WindowManager.LayoutParams.PRIVATE_FLAG_PREVENT_POWER_KEY) != 0){
+            mContext.enforceCallingOrSelfPermission("android.permission.PREVENT_POWER_KEY",
+                    "No permission to prevent power key");
+        }
         final WindowManager.LayoutParams attrs = getAttributes();
         attrs.privateFlags = (attrs.privateFlags & ~mask) | (flags & mask);
         dispatchWindowAttributesChanged(attrs);

--- a/core/java/android/view/WindowManager.java
+++ b/core/java/android/view/WindowManager.java
@@ -1120,6 +1120,12 @@ public interface WindowManager extends ViewManager {
         public static final int PRIVATE_FLAG_FULLY_TRANSPARENT = 0x10000000;
 
         /**
+         * Window flag: Overrides default power key behavior
+         * {@hide}
+         */
+        public static final int PRIVATE_FLAG_PREVENT_POWER_KEY = 0x20000000;
+
+        /**
          * Control flags that are private to the platform.
          * @hide
          */

--- a/core/res/AndroidManifest.xml
+++ b/core/res/AndroidManifest.xml
@@ -996,6 +996,14 @@
         android:description="@string/permdesc_changeWifiMulticastState"
         android:label="@string/permlab_changeWifiMulticastState" />
 
+    <!-- Allows an application to override the power key action
+        @hide -->
+    <permission android:name="android.permission.PREVENT_POWER_KEY"
+        android:permissionGroup="android.permission-group.HARDWARE_CONTROLS"
+        android:protectionLevel="dangerous"
+        android:label="@string/permlab_preventpower"
+        android:description="@string/permdesc_preventpower" />
+
     <!-- Allows access to the vibrator -->
     <permission android:name="android.permission.VIBRATE"
         android:permissionGroup="android.permission-group.AFFECTS_BATTERY"

--- a/core/res/res/values/pa_strings.xml
+++ b/core/res/res/values/pa_strings.xml
@@ -80,4 +80,8 @@
     <!-- [CHAR LIMIT=40] Title of dialog that is shown when performing a system install. -->
     <string name="android_installing_title">Android is installing\u2026</string>
 
+    <string name="permlab_preventpower">override power key</string>
+    <!-- Description of an application permission, listed so the user can choose whether they want to allow the application to do this. -->
+    <string name="permdesc_preventpower">Allows an app to override the power key.</string>
+
 </resources>

--- a/policy/src/com/android/internal/policy/impl/PhoneWindowManager.java
+++ b/policy/src/com/android/internal/policy/impl/PhoneWindowManager.java
@@ -4862,6 +4862,10 @@ public class PhoneWindowManager implements WindowManagerPolicy {
             }
 
             case KeyEvent.KEYCODE_POWER: {
+                if ((mTopFullscreenOpaqueWindowState.getAttrs().privateFlags
+                        & WindowManager.LayoutParams.PRIVATE_FLAG_PREVENT_POWER_KEY) != 0){
+                    return result;
+                }
                 result &= ~ACTION_PASS_TO_USER;
                 if (down) {
                     if (interactive && !mPowerKeyTriggered


### PR DESCRIPTION
Provides a way for an app to take control of the power key.
Used by the camera to make the power key control the shutter.

Fix typo in @hide annotation for PRIVATE_FLAG_PREVENT_POWER_KEY

Change-Id: I19622ffe177553cd5a80022e76a54f8e16e49cac

Fix Power Shutter Exception 2 of 2

Set protection level to 'dangerous'

Change-Id: I9792f4c543c9ce8a647989ca60cdc9389602551c

Change-Id: I85a1e1761199f4604672be42a3a5005227f5451a
