### PR TITLE
[1/2] Frameworks: let InCallUI handle proximity sensor for incoming call...

### DIFF
--- a/services/core/java/com/android/server/power/PowerManagerService.java
+++ b/services/core/java/com/android/server/power/PowerManagerService.java
@@ -65,6 +65,7 @@ import android.os.UserHandle;
 import android.os.WorkSource;
 import android.provider.Settings;
 import android.service.dreams.DreamManagerInternal;
+import android.telephony.TelephonyManager;
 import android.util.EventLog;
 import android.util.Log;
 import android.util.Slog;
@@ -187,6 +188,8 @@ public final class PowerManagerService extends SystemService
     private DreamManagerInternal mDreamManager;
     private Light mAttentionLight;
     private Light mButtonsLight;
+
+    private TelephonyManager mTelephonyManager;
 
     private int mButtonTimeout;
     private int mButtonBrightness;
@@ -3086,7 +3089,12 @@ public final class PowerManagerService extends SystemService
                 // There is already a message queued;
                 return;
             }
-            if (mProximityWakeSupported && mProximityWakeEnabled && mProximitySensor != null) {
+
+            boolean hasIncomingCall = (getTelephonyManager().getCallState()
+                    == TelephonyManager.CALL_STATE_RINGING);
+
+            if (mProximityWakeSupported && mProximityWakeEnabled && mProximitySensor != null
+                    && !hasIncomingCall) {
                 Message msg = mHandler.obtainMessage(MSG_WAKE_UP);
                 msg.obj = r;
                 mHandler.sendMessageDelayed(msg, mProximityTimeOut);
@@ -3094,6 +3102,14 @@ public final class PowerManagerService extends SystemService
             } else {
                 r.run();
             }
+        }
+
+        TelephonyManager getTelephonyManager() {
+            if (mTelephonyManager == null) {
+                mTelephonyManager = (TelephonyManager)mContext.getSystemService(
+                        Context.TELEPHONY_SERVICE);
+            }
+            return mTelephonyManager;
         }
 
         private void runPostProximityCheck(final Runnable r) {


### PR DESCRIPTION
...s

fixes "while 'prevent accidental wake-up' is on, proximity sensor
        doesn't control screen state on incoming call.  must manually
        turn on screen to see who's calling."

Change-Id: I738b3bbd328992c8a8010a0c8d9aa1e444cfa9f9
